### PR TITLE
Prevent to earn point with multiple clicking

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@ square.forEach(id => {
     if(id.id === hitPosition){
       result = result + 1
       score.textContent = result
+      hitPosition=null
     }
   })
 })


### PR DESCRIPTION
When multiple clicking user can get more and more points. Assign hitPosition to null after earn point.