### PR TITLE
Reload Game after first time

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,8 +41,8 @@ function countDown() {
   timeLeft.textContent = currentTime
 
   if(currentTime === 0 ) {
-    clearInterval(timerId)
     alert('GAME OVER! Your final score is' + result)
+    location.reload()
   }
 }
 


### PR DESCRIPTION
The timer is not reset back to 60 once the game ends. The second game could not be played without manually refreshing the page since the timer remained at zero but the score continued to increase on whacking the mole. So I have added the code to reload the page once the game ends.